### PR TITLE
Add properties to GameControl to control when the game loop should up…

### DIFF
--- a/MonoGame.Forms.DX/Controls/GameControl.cs
+++ b/MonoGame.Forms.DX/Controls/GameControl.cs
@@ -16,6 +16,21 @@ namespace MonoGame.Forms.Controls
         internal TimeSpan _Elapsed;
 
         /// <summary>
+        /// Set this to 'true' if you would like the game loop to run when the component is not visible.
+        /// <remarks>
+        /// By default the game loop will not run when <see cref="Control.Visible"/>' is set to false. 
+        /// This happens for example when the game window is part of a tab that is not currently open.
+        /// </remarks>
+        /// </summary>
+        public bool UpdateGameLoopWhenNotVisible { get; set; } = false;
+
+
+        /// <summary>
+        /// Setting this to 'false' will stop the game loop from running until it is set back to 'true'
+        /// </summary>
+        public bool ShouldUpdateGameLoop { get; set; } = true;
+
+        /// <summary>
         /// Set this to 'true' to only update this control when the mouse cursor is inside (OnMouseHover).
         /// <remarks>
         /// This technique is useful when you only need to update this control temporarily or always on demand.
@@ -69,7 +84,7 @@ namespace MonoGame.Forms.Controls
 
         private void GameLoop(object sender, EventArgs e)
         {
-            if (Visible)
+            if ((Visible || UpdateGameLoopWhenNotVisible) && ShouldUpdateGameLoop)
             {
                 _GameTime = new GameTime(_Timer.Elapsed, _Timer.Elapsed - _Elapsed);
                 _Elapsed = _Timer.Elapsed;

--- a/MonoGame.Forms.Tests.DX/MainWindow.Designer.cs
+++ b/MonoGame.Forms.Tests.DX/MainWindow.Designer.cs
@@ -33,12 +33,10 @@
             this.tabPageWelcome = new System.Windows.Forms.TabPage();
             this.trackBarLogoFrames = new System.Windows.Forms.TrackBar();
             this.buttonEdit = new System.Windows.Forms.Button();
-            this.welcomeControl = new MonoGame.Forms.Tests.Tests.Welcome();
             this.tabPageDrawControl = new System.Windows.Forms.TabPage();
             this.panelInvalidation = new System.Windows.Forms.Panel();
             this.buttonInvalidate = new System.Windows.Forms.Button();
             this.textBoxTestText = new System.Windows.Forms.TextBox();
-            this.invalidationTestControl = new MonoGame.Forms.Tests.Tests.InvalidationTest();
             this.tabPageUpdateControl = new System.Windows.Forms.TabPage();
             this.buttonHelp = new System.Windows.Forms.Button();
             this.trackBarCamZoom = new System.Windows.Forms.TrackBar();
@@ -47,24 +45,28 @@
             this.checkBoxFPS = new System.Windows.Forms.CheckBox();
             this.buttonResetCam = new System.Windows.Forms.Button();
             this.buttonMoveCam = new System.Windows.Forms.Button();
-            this.monoGameTestControl = new MonoGame.Forms.Tests.Tests.MonoGameTest();
             this.tabPageAdvancedInput = new System.Windows.Forms.TabPage();
             this.buttonHelpInput = new System.Windows.Forms.Button();
             this.checkBoxShowHelp = new System.Windows.Forms.CheckBox();
             this.checkBoxShowStats = new System.Windows.Forms.CheckBox();
             this.buttonResetPlayer = new System.Windows.Forms.Button();
-            this.advancedControlsTest = new MonoGame.Forms.Tests.Tests.AdvancedInputTest();
             this.tabPageMultipleControls = new System.Windows.Forms.TabPage();
             this.splitContainerMapHost = new System.Windows.Forms.SplitContainer();
             this.buttonHelpControls = new System.Windows.Forms.Button();
-            this.multipleControls_First_Test1 = new MonoGame.Forms.Tests.Tests.MultipleControls_a_Test();
-            this.multipleControls_Second_Test1 = new MonoGame.Forms.Tests.Tests.MultipleControls_b_Test();
             this.tabPageInfo = new System.Windows.Forms.TabPage();
             this.richTextBoxLicense = new System.Windows.Forms.RichTextBox();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.toolStripDropDownButtonGitHub = new System.Windows.Forms.ToolStripDropDownButton();
             this.toolStripDropDownButtonWiki = new System.Windows.Forms.ToolStripDropDownButton();
             this.toolStripDropDownButtonTwitter = new System.Windows.Forms.ToolStripDropDownButton();
+            this.updateGameLoopNotVisibleCheckBox = new System.Windows.Forms.CheckBox();
+            this.updateGameLoopCheckBox = new System.Windows.Forms.CheckBox();
+            this.welcomeControl = new MonoGame.Forms.Tests.Tests.Welcome();
+            this.invalidationTestControl = new MonoGame.Forms.Tests.Tests.InvalidationTest();
+            this.monoGameTestControl = new MonoGame.Forms.Tests.Tests.MonoGameTest();
+            this.advancedControlsTest = new MonoGame.Forms.Tests.Tests.AdvancedInputTest();
+            this.multipleControls_First_Test1 = new MonoGame.Forms.Tests.Tests.MultipleControls_a_Test();
+            this.multipleControls_Second_Test1 = new MonoGame.Forms.Tests.Tests.MultipleControls_b_Test();
             this.tabControlEditorSwitch.SuspendLayout();
             this.tabPageWelcome.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarLogoFrames)).BeginInit();
@@ -99,12 +101,14 @@
             // 
             // tabPageWelcome
             // 
+            this.tabPageWelcome.Controls.Add(this.updateGameLoopCheckBox);
+            this.tabPageWelcome.Controls.Add(this.updateGameLoopNotVisibleCheckBox);
             this.tabPageWelcome.Controls.Add(this.trackBarLogoFrames);
             this.tabPageWelcome.Controls.Add(this.buttonEdit);
             this.tabPageWelcome.Controls.Add(this.welcomeControl);
-            this.tabPageWelcome.Location = new System.Drawing.Point(4, 25);
+            this.tabPageWelcome.Location = new System.Drawing.Point(4, 22);
             this.tabPageWelcome.Name = "tabPageWelcome";
-            this.tabPageWelcome.Size = new System.Drawing.Size(728, 399);
+            this.tabPageWelcome.Size = new System.Drawing.Size(728, 402);
             this.tabPageWelcome.TabIndex = 2;
             this.tabPageWelcome.Text = "Welcome";
             this.tabPageWelcome.UseVisualStyleBackColor = true;
@@ -113,10 +117,10 @@
             // 
             this.trackBarLogoFrames.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.trackBarLogoFrames.LargeChange = 1;
-            this.trackBarLogoFrames.Location = new System.Drawing.Point(0, 343);
+            this.trackBarLogoFrames.Location = new System.Drawing.Point(0, 357);
             this.trackBarLogoFrames.Maximum = 99;
             this.trackBarLogoFrames.Name = "trackBarLogoFrames";
-            this.trackBarLogoFrames.Size = new System.Drawing.Size(728, 56);
+            this.trackBarLogoFrames.Size = new System.Drawing.Size(728, 45);
             this.trackBarLogoFrames.TabIndex = 2;
             this.trackBarLogoFrames.Visible = false;
             this.trackBarLogoFrames.Scroll += new System.EventHandler(this.trackBarLogoFrames_Scroll);
@@ -132,26 +136,15 @@
             this.buttonEdit.UseVisualStyleBackColor = true;
             this.buttonEdit.Click += new System.EventHandler(this.buttonEdit_Click);
             // 
-            // welcomeControl
-            // 
-            this.welcomeControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.welcomeControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.welcomeControl.Location = new System.Drawing.Point(0, 0);
-            this.welcomeControl.MouseHoverUpdatesOnly = false;
-            this.welcomeControl.Name = "welcomeControl";
-            this.welcomeControl.Size = new System.Drawing.Size(728, 399);
-            this.welcomeControl.TabIndex = 3;
-            this.welcomeControl.Text = "Welcome to MonoGame.Forms!";
-            // 
             // tabPageDrawControl
             // 
             this.tabPageDrawControl.Controls.Add(this.panelInvalidation);
             this.tabPageDrawControl.Controls.Add(this.textBoxTestText);
             this.tabPageDrawControl.Controls.Add(this.invalidationTestControl);
-            this.tabPageDrawControl.Location = new System.Drawing.Point(4, 25);
+            this.tabPageDrawControl.Location = new System.Drawing.Point(4, 22);
             this.tabPageDrawControl.Name = "tabPageDrawControl";
             this.tabPageDrawControl.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageDrawControl.Size = new System.Drawing.Size(728, 399);
+            this.tabPageDrawControl.Size = new System.Drawing.Size(728, 402);
             this.tabPageDrawControl.TabIndex = 0;
             this.tabPageDrawControl.Text = "Invalidation Control";
             this.tabPageDrawControl.UseVisualStyleBackColor = true;
@@ -161,7 +154,7 @@
             this.panelInvalidation.BackColor = System.Drawing.Color.CornflowerBlue;
             this.panelInvalidation.Controls.Add(this.buttonInvalidate);
             this.panelInvalidation.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panelInvalidation.Location = new System.Drawing.Point(3, 312);
+            this.panelInvalidation.Location = new System.Drawing.Point(3, 315);
             this.panelInvalidation.Name = "panelInvalidation";
             this.panelInvalidation.Size = new System.Drawing.Size(722, 34);
             this.panelInvalidation.TabIndex = 4;
@@ -183,7 +176,7 @@
             this.textBoxTestText.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.textBoxTestText.Font = new System.Drawing.Font("Microsoft Sans Serif", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.textBoxTestText.ForeColor = System.Drawing.SystemColors.Control;
-            this.textBoxTestText.Location = new System.Drawing.Point(3, 346);
+            this.textBoxTestText.Location = new System.Drawing.Point(3, 349);
             this.textBoxTestText.Multiline = true;
             this.textBoxTestText.Name = "textBoxTestText";
             this.textBoxTestText.Size = new System.Drawing.Size(722, 50);
@@ -191,19 +184,6 @@
             this.textBoxTestText.Text = "Edit Me!";
             this.textBoxTestText.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.textBoxTestText.TextChanged += new System.EventHandler(this.textBoxTestText_TextChanged);
-            // 
-            // invalidationTestControl
-            // 
-            this.invalidationTestControl.BackColor = System.Drawing.Color.CornflowerBlue;
-            this.invalidationTestControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.invalidationTestControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.invalidationTestControl.ForeColor = System.Drawing.Color.Yellow;
-            this.invalidationTestControl.Location = new System.Drawing.Point(3, 3);
-            this.invalidationTestControl.Name = "invalidationTestControl";
-            this.invalidationTestControl.Size = new System.Drawing.Size(722, 393);
-            this.invalidationTestControl.TabIndex = 5;
-            this.invalidationTestControl.Text = "This \'InvalidationControl\' has no game loop, but it\'s updated through invalidatio" +
-    "n!";
             // 
             // tabPageUpdateControl
             // 
@@ -215,10 +195,10 @@
             this.tabPageUpdateControl.Controls.Add(this.buttonResetCam);
             this.tabPageUpdateControl.Controls.Add(this.buttonMoveCam);
             this.tabPageUpdateControl.Controls.Add(this.monoGameTestControl);
-            this.tabPageUpdateControl.Location = new System.Drawing.Point(4, 25);
+            this.tabPageUpdateControl.Location = new System.Drawing.Point(4, 22);
             this.tabPageUpdateControl.Name = "tabPageUpdateControl";
             this.tabPageUpdateControl.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageUpdateControl.Size = new System.Drawing.Size(728, 399);
+            this.tabPageUpdateControl.Size = new System.Drawing.Size(728, 402);
             this.tabPageUpdateControl.TabIndex = 1;
             this.tabPageUpdateControl.Text = "MonoGame Control";
             this.tabPageUpdateControl.UseVisualStyleBackColor = true;
@@ -227,7 +207,7 @@
             // 
             this.buttonHelp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonHelp.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonHelp.Location = new System.Drawing.Point(9, 338);
+            this.buttonHelp.Location = new System.Drawing.Point(9, 341);
             this.buttonHelp.Name = "buttonHelp";
             this.buttonHelp.Size = new System.Drawing.Size(28, 25);
             this.buttonHelp.TabIndex = 7;
@@ -244,7 +224,7 @@
             this.trackBarCamZoom.Maximum = 8;
             this.trackBarCamZoom.Name = "trackBarCamZoom";
             this.trackBarCamZoom.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBarCamZoom.Size = new System.Drawing.Size(56, 296);
+            this.trackBarCamZoom.Size = new System.Drawing.Size(45, 299);
             this.trackBarCamZoom.TabIndex = 6;
             this.trackBarCamZoom.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
             this.trackBarCamZoom.Scroll += new System.EventHandler(this.trackBarCamZoom_Scroll);
@@ -253,9 +233,9 @@
             // 
             this.checkBoxCam.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.checkBoxCam.AutoSize = true;
-            this.checkBoxCam.Location = new System.Drawing.Point(149, 369);
+            this.checkBoxCam.Location = new System.Drawing.Point(149, 376);
             this.checkBoxCam.Name = "checkBoxCam";
-            this.checkBoxCam.Size = new System.Drawing.Size(58, 21);
+            this.checkBoxCam.Size = new System.Drawing.Size(47, 17);
             this.checkBoxCam.TabIndex = 5;
             this.checkBoxCam.Text = "Cam";
             this.checkBoxCam.UseVisualStyleBackColor = true;
@@ -267,9 +247,9 @@
             this.checkBoxCursor.AutoSize = true;
             this.checkBoxCursor.Checked = true;
             this.checkBoxCursor.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxCursor.Location = new System.Drawing.Point(71, 369);
+            this.checkBoxCursor.Location = new System.Drawing.Point(71, 376);
             this.checkBoxCursor.Name = "checkBoxCursor";
-            this.checkBoxCursor.Size = new System.Drawing.Size(72, 21);
+            this.checkBoxCursor.Size = new System.Drawing.Size(56, 17);
             this.checkBoxCursor.TabIndex = 4;
             this.checkBoxCursor.Text = "Cursor";
             this.checkBoxCursor.UseVisualStyleBackColor = true;
@@ -281,9 +261,9 @@
             this.checkBoxFPS.AutoSize = true;
             this.checkBoxFPS.Checked = true;
             this.checkBoxFPS.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxFPS.Location = new System.Drawing.Point(9, 369);
+            this.checkBoxFPS.Location = new System.Drawing.Point(9, 376);
             this.checkBoxFPS.Name = "checkBoxFPS";
-            this.checkBoxFPS.Size = new System.Drawing.Size(56, 21);
+            this.checkBoxFPS.Size = new System.Drawing.Size(46, 17);
             this.checkBoxFPS.TabIndex = 3;
             this.checkBoxFPS.Text = "FPS";
             this.checkBoxFPS.UseVisualStyleBackColor = true;
@@ -292,7 +272,7 @@
             // buttonResetCam
             // 
             this.buttonResetCam.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonResetCam.Location = new System.Drawing.Point(611, 308);
+            this.buttonResetCam.Location = new System.Drawing.Point(611, 311);
             this.buttonResetCam.Name = "buttonResetCam";
             this.buttonResetCam.Size = new System.Drawing.Size(109, 30);
             this.buttonResetCam.TabIndex = 2;
@@ -304,7 +284,7 @@
             // 
             this.buttonMoveCam.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonMoveCam.Cursor = System.Windows.Forms.Cursors.SizeAll;
-            this.buttonMoveCam.Location = new System.Drawing.Point(611, 344);
+            this.buttonMoveCam.Location = new System.Drawing.Point(611, 347);
             this.buttonMoveCam.Name = "buttonMoveCam";
             this.buttonMoveCam.Size = new System.Drawing.Size(109, 49);
             this.buttonMoveCam.TabIndex = 1;
@@ -314,19 +294,6 @@
             this.buttonMoveCam.MouseMove += new System.Windows.Forms.MouseEventHandler(this.buttonMoveCam_MouseMove);
             this.buttonMoveCam.MouseUp += new System.Windows.Forms.MouseEventHandler(this.buttonMoveCam_MouseUp);
             // 
-            // monoGameTestControl
-            // 
-            this.monoGameTestControl.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.monoGameTestControl.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.monoGameTestControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.monoGameTestControl.Location = new System.Drawing.Point(3, 3);
-            this.monoGameTestControl.MouseHoverUpdatesOnly = false;
-            this.monoGameTestControl.Name = "monoGameTestControl";
-            this.monoGameTestControl.Size = new System.Drawing.Size(722, 393);
-            this.monoGameTestControl.TabIndex = 8;
-            this.monoGameTestControl.Text = "The \'MonoGameControl\' has a game loop!";
-            this.monoGameTestControl.VisibleChanged += new System.EventHandler(this.monoGameTestControl_VisibleChanged);
-            // 
             // tabPageAdvancedInput
             // 
             this.tabPageAdvancedInput.Controls.Add(this.buttonHelpInput);
@@ -334,9 +301,9 @@
             this.tabPageAdvancedInput.Controls.Add(this.checkBoxShowStats);
             this.tabPageAdvancedInput.Controls.Add(this.buttonResetPlayer);
             this.tabPageAdvancedInput.Controls.Add(this.advancedControlsTest);
-            this.tabPageAdvancedInput.Location = new System.Drawing.Point(4, 25);
+            this.tabPageAdvancedInput.Location = new System.Drawing.Point(4, 22);
             this.tabPageAdvancedInput.Name = "tabPageAdvancedInput";
-            this.tabPageAdvancedInput.Size = new System.Drawing.Size(728, 399);
+            this.tabPageAdvancedInput.Size = new System.Drawing.Size(728, 402);
             this.tabPageAdvancedInput.TabIndex = 4;
             this.tabPageAdvancedInput.Text = "Advanced Input";
             this.tabPageAdvancedInput.UseVisualStyleBackColor = true;
@@ -345,7 +312,7 @@
             // 
             this.buttonHelpInput.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonHelpInput.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonHelpInput.Location = new System.Drawing.Point(114, 360);
+            this.buttonHelpInput.Location = new System.Drawing.Point(114, 363);
             this.buttonHelpInput.Name = "buttonHelpInput";
             this.buttonHelpInput.Size = new System.Drawing.Size(59, 31);
             this.buttonHelpInput.TabIndex = 4;
@@ -359,9 +326,9 @@
             this.checkBoxShowHelp.AutoSize = true;
             this.checkBoxShowHelp.Checked = true;
             this.checkBoxShowHelp.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxShowHelp.Location = new System.Drawing.Point(8, 333);
+            this.checkBoxShowHelp.Location = new System.Drawing.Point(8, 340);
             this.checkBoxShowHelp.Name = "checkBoxShowHelp";
-            this.checkBoxShowHelp.Size = new System.Drawing.Size(97, 21);
+            this.checkBoxShowHelp.Size = new System.Drawing.Size(78, 17);
             this.checkBoxShowHelp.TabIndex = 3;
             this.checkBoxShowHelp.Text = "Show Help";
             this.checkBoxShowHelp.UseVisualStyleBackColor = true;
@@ -373,9 +340,9 @@
             this.checkBoxShowStats.AutoSize = true;
             this.checkBoxShowStats.Checked = true;
             this.checkBoxShowStats.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBoxShowStats.Location = new System.Drawing.Point(8, 306);
+            this.checkBoxShowStats.Location = new System.Drawing.Point(8, 313);
             this.checkBoxShowStats.Name = "checkBoxShowStats";
-            this.checkBoxShowStats.Size = new System.Drawing.Size(100, 21);
+            this.checkBoxShowStats.Size = new System.Drawing.Size(80, 17);
             this.checkBoxShowStats.TabIndex = 2;
             this.checkBoxShowStats.Text = "Show Stats";
             this.checkBoxShowStats.UseVisualStyleBackColor = true;
@@ -384,7 +351,7 @@
             // buttonResetPlayer
             // 
             this.buttonResetPlayer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.buttonResetPlayer.Location = new System.Drawing.Point(8, 360);
+            this.buttonResetPlayer.Location = new System.Drawing.Point(8, 363);
             this.buttonResetPlayer.Name = "buttonResetPlayer";
             this.buttonResetPlayer.Size = new System.Drawing.Size(100, 31);
             this.buttonResetPlayer.TabIndex = 1;
@@ -392,25 +359,12 @@
             this.buttonResetPlayer.UseVisualStyleBackColor = true;
             this.buttonResetPlayer.Click += new System.EventHandler(this.buttonResetPlayer_Click);
             // 
-            // advancedControlsTest
-            // 
-            this.advancedControlsTest.BackColor = System.Drawing.Color.DarkSeaGreen;
-            this.advancedControlsTest.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.advancedControlsTest.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.advancedControlsTest.ForeColor = System.Drawing.Color.FloralWhite;
-            this.advancedControlsTest.Location = new System.Drawing.Point(0, 0);
-            this.advancedControlsTest.MouseHoverUpdatesOnly = false;
-            this.advancedControlsTest.Name = "advancedControlsTest";
-            this.advancedControlsTest.Size = new System.Drawing.Size(728, 399);
-            this.advancedControlsTest.TabIndex = 0;
-            this.advancedControlsTest.Text = "Test Keyboard, Mouse and GamePad input here!";
-            // 
             // tabPageMultipleControls
             // 
             this.tabPageMultipleControls.Controls.Add(this.splitContainerMapHost);
-            this.tabPageMultipleControls.Location = new System.Drawing.Point(4, 25);
+            this.tabPageMultipleControls.Location = new System.Drawing.Point(4, 22);
             this.tabPageMultipleControls.Name = "tabPageMultipleControls";
-            this.tabPageMultipleControls.Size = new System.Drawing.Size(728, 399);
+            this.tabPageMultipleControls.Size = new System.Drawing.Size(728, 402);
             this.tabPageMultipleControls.TabIndex = 5;
             this.tabPageMultipleControls.Text = "Multiple Controls";
             this.tabPageMultipleControls.UseVisualStyleBackColor = true;
@@ -429,7 +383,7 @@
             // splitContainerMapHost.Panel2
             // 
             this.splitContainerMapHost.Panel2.Controls.Add(this.multipleControls_Second_Test1);
-            this.splitContainerMapHost.Size = new System.Drawing.Size(728, 399);
+            this.splitContainerMapHost.Size = new System.Drawing.Size(728, 402);
             this.splitContainerMapHost.SplitterDistance = 350;
             this.splitContainerMapHost.TabIndex = 3;
             this.splitContainerMapHost.VisibleChanged += new System.EventHandler(this.splitContainerMapHost_VisibleChanged);
@@ -438,7 +392,7 @@
             // 
             this.buttonHelpControls.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.buttonHelpControls.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.buttonHelpControls.Location = new System.Drawing.Point(3, 372);
+            this.buttonHelpControls.Location = new System.Drawing.Point(3, 375);
             this.buttonHelpControls.Name = "buttonHelpControls";
             this.buttonHelpControls.Size = new System.Drawing.Size(75, 24);
             this.buttonHelpControls.TabIndex = 2;
@@ -446,39 +400,13 @@
             this.buttonHelpControls.UseVisualStyleBackColor = true;
             this.buttonHelpControls.Click += new System.EventHandler(this.buttonHelpControls_Click);
             // 
-            // multipleControls_First_Test1
-            // 
-            this.multipleControls_First_Test1.BackColor = System.Drawing.Color.LightSeaGreen;
-            this.multipleControls_First_Test1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.multipleControls_First_Test1.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.multipleControls_First_Test1.ForeColor = System.Drawing.Color.Lavender;
-            this.multipleControls_First_Test1.Location = new System.Drawing.Point(0, 0);
-            this.multipleControls_First_Test1.MouseHoverUpdatesOnly = false;
-            this.multipleControls_First_Test1.Name = "multipleControls_First_Test1";
-            this.multipleControls_First_Test1.Size = new System.Drawing.Size(350, 399);
-            this.multipleControls_First_Test1.TabIndex = 0;
-            this.multipleControls_First_Test1.Text = "Left Map";
-            // 
-            // multipleControls_Second_Test1
-            // 
-            this.multipleControls_Second_Test1.BackColor = System.Drawing.Color.RoyalBlue;
-            this.multipleControls_Second_Test1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.multipleControls_Second_Test1.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.multipleControls_Second_Test1.ForeColor = System.Drawing.Color.Lavender;
-            this.multipleControls_Second_Test1.Location = new System.Drawing.Point(0, 0);
-            this.multipleControls_Second_Test1.MouseHoverUpdatesOnly = false;
-            this.multipleControls_Second_Test1.Name = "multipleControls_Second_Test1";
-            this.multipleControls_Second_Test1.Size = new System.Drawing.Size(374, 399);
-            this.multipleControls_Second_Test1.TabIndex = 1;
-            this.multipleControls_Second_Test1.Text = "Right Map";
-            // 
             // tabPageInfo
             // 
             this.tabPageInfo.Controls.Add(this.richTextBoxLicense);
             this.tabPageInfo.Controls.Add(this.statusStrip);
-            this.tabPageInfo.Location = new System.Drawing.Point(4, 25);
+            this.tabPageInfo.Location = new System.Drawing.Point(4, 22);
             this.tabPageInfo.Name = "tabPageInfo";
-            this.tabPageInfo.Size = new System.Drawing.Size(728, 399);
+            this.tabPageInfo.Size = new System.Drawing.Size(728, 402);
             this.tabPageInfo.TabIndex = 3;
             this.tabPageInfo.Text = "Info";
             this.tabPageInfo.UseVisualStyleBackColor = true;
@@ -489,7 +417,7 @@
             this.richTextBoxLicense.Dock = System.Windows.Forms.DockStyle.Fill;
             this.richTextBoxLicense.Location = new System.Drawing.Point(0, 0);
             this.richTextBoxLicense.Name = "richTextBoxLicense";
-            this.richTextBoxLicense.Size = new System.Drawing.Size(728, 361);
+            this.richTextBoxLicense.Size = new System.Drawing.Size(728, 371);
             this.richTextBoxLicense.TabIndex = 1;
             this.richTextBoxLicense.Text = resources.GetString("richTextBoxLicense.Text");
             this.richTextBoxLicense.ZoomFactor = 1.5F;
@@ -501,9 +429,9 @@
             this.toolStripDropDownButtonGitHub,
             this.toolStripDropDownButtonWiki,
             this.toolStripDropDownButtonTwitter});
-            this.statusStrip.Location = new System.Drawing.Point(0, 361);
+            this.statusStrip.Location = new System.Drawing.Point(0, 371);
             this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(728, 38);
+            this.statusStrip.Size = new System.Drawing.Size(728, 31);
             this.statusStrip.SizingGrip = false;
             this.statusStrip.TabIndex = 0;
             // 
@@ -513,7 +441,7 @@
             this.toolStripDropDownButtonGitHub.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButtonGitHub.Image")));
             this.toolStripDropDownButtonGitHub.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripDropDownButtonGitHub.Name = "toolStripDropDownButtonGitHub";
-            this.toolStripDropDownButtonGitHub.Size = new System.Drawing.Size(259, 36);
+            this.toolStripDropDownButtonGitHub.Size = new System.Drawing.Size(210, 29);
             this.toolStripDropDownButtonGitHub.Text = "MonoGame.Forms";
             this.toolStripDropDownButtonGitHub.Click += new System.EventHandler(this.toolStripDropDownButtonGitHub_Click);
             // 
@@ -523,7 +451,7 @@
             this.toolStripDropDownButtonWiki.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButtonWiki.Image")));
             this.toolStripDropDownButtonWiki.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripDropDownButtonWiki.Name = "toolStripDropDownButtonWiki";
-            this.toolStripDropDownButtonWiki.Size = new System.Drawing.Size(100, 36);
+            this.toolStripDropDownButtonWiki.Size = new System.Drawing.Size(85, 29);
             this.toolStripDropDownButtonWiki.Text = "Wiki";
             this.toolStripDropDownButtonWiki.Click += new System.EventHandler(this.toolStripDropDownButtonWiki_Click);
             // 
@@ -533,9 +461,119 @@
             this.toolStripDropDownButtonTwitter.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButtonTwitter.Image")));
             this.toolStripDropDownButtonTwitter.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripDropDownButtonTwitter.Name = "toolStripDropDownButtonTwitter";
-            this.toolStripDropDownButtonTwitter.Size = new System.Drawing.Size(224, 36);
+            this.toolStripDropDownButtonTwitter.Size = new System.Drawing.Size(183, 29);
             this.toolStripDropDownButtonTwitter.Text = "@SandboxBlizz";
             this.toolStripDropDownButtonTwitter.Click += new System.EventHandler(this.toolStripDropDownButtonTwitter_Click);
+            // 
+            // updateGameLoopNotVisibleCheckBox
+            // 
+            this.updateGameLoopNotVisibleCheckBox.AutoSize = true;
+            this.updateGameLoopNotVisibleCheckBox.Location = new System.Drawing.Point(498, 7);
+            this.updateGameLoopNotVisibleCheckBox.Name = "updateGameLoopNotVisibleCheckBox";
+            this.updateGameLoopNotVisibleCheckBox.Size = new System.Drawing.Size(146, 17);
+            this.updateGameLoopNotVisibleCheckBox.TabIndex = 4;
+            this.updateGameLoopNotVisibleCheckBox.Text = "Update When Not Visible";
+            this.updateGameLoopNotVisibleCheckBox.UseVisualStyleBackColor = true;
+            this.updateGameLoopNotVisibleCheckBox.CheckedChanged += new System.EventHandler(this.updateGameLoopNotVisibleCheckBox_CheckedChanged);
+            // 
+            // updateGameLoopCheckBox
+            // 
+            this.updateGameLoopCheckBox.AutoSize = true;
+            this.updateGameLoopCheckBox.Checked = true;
+            this.updateGameLoopCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.updateGameLoopCheckBox.Location = new System.Drawing.Point(373, 7);
+            this.updateGameLoopCheckBox.Name = "updateGameLoopCheckBox";
+            this.updateGameLoopCheckBox.Size = new System.Drawing.Size(119, 17);
+            this.updateGameLoopCheckBox.TabIndex = 5;
+            this.updateGameLoopCheckBox.Text = "Update Game Loop";
+            this.updateGameLoopCheckBox.UseVisualStyleBackColor = true;
+            this.updateGameLoopCheckBox.CheckedChanged += new System.EventHandler(this.updateGameLoopCheckBox_CheckedChanged);
+            // 
+            // welcomeControl
+            // 
+            this.welcomeControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.welcomeControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.welcomeControl.Location = new System.Drawing.Point(0, 0);
+            this.welcomeControl.MouseHoverUpdatesOnly = false;
+            this.welcomeControl.Name = "welcomeControl";
+            this.welcomeControl.ShouldUpdateGameLoop = true;
+            this.welcomeControl.Size = new System.Drawing.Size(728, 402);
+            this.welcomeControl.TabIndex = 3;
+            this.welcomeControl.Text = "Welcome to MonoGame.Forms!";
+            this.welcomeControl.UpdateGameLoopWhenNotVisible = false;
+            // 
+            // invalidationTestControl
+            // 
+            this.invalidationTestControl.BackColor = System.Drawing.Color.CornflowerBlue;
+            this.invalidationTestControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.invalidationTestControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.invalidationTestControl.ForeColor = System.Drawing.Color.Yellow;
+            this.invalidationTestControl.Location = new System.Drawing.Point(3, 3);
+            this.invalidationTestControl.Name = "invalidationTestControl";
+            this.invalidationTestControl.Size = new System.Drawing.Size(722, 396);
+            this.invalidationTestControl.TabIndex = 5;
+            this.invalidationTestControl.Text = "This \'InvalidationControl\' has no game loop, but it\'s updated through invalidatio" +
+    "n!";
+            // 
+            // monoGameTestControl
+            // 
+            this.monoGameTestControl.BackColor = System.Drawing.Color.PaleGoldenrod;
+            this.monoGameTestControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.monoGameTestControl.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.monoGameTestControl.Location = new System.Drawing.Point(3, 3);
+            this.monoGameTestControl.MouseHoverUpdatesOnly = false;
+            this.monoGameTestControl.Name = "monoGameTestControl";
+            this.monoGameTestControl.ShouldUpdateGameLoop = true;
+            this.monoGameTestControl.Size = new System.Drawing.Size(722, 396);
+            this.monoGameTestControl.TabIndex = 8;
+            this.monoGameTestControl.Text = "The \'MonoGameControl\' has a game loop!";
+            this.monoGameTestControl.UpdateGameLoopWhenNotVisible = false;
+            this.monoGameTestControl.VisibleChanged += new System.EventHandler(this.monoGameTestControl_VisibleChanged);
+            // 
+            // advancedControlsTest
+            // 
+            this.advancedControlsTest.BackColor = System.Drawing.Color.DarkSeaGreen;
+            this.advancedControlsTest.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.advancedControlsTest.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.advancedControlsTest.ForeColor = System.Drawing.Color.FloralWhite;
+            this.advancedControlsTest.Location = new System.Drawing.Point(0, 0);
+            this.advancedControlsTest.MouseHoverUpdatesOnly = false;
+            this.advancedControlsTest.Name = "advancedControlsTest";
+            this.advancedControlsTest.ShouldUpdateGameLoop = true;
+            this.advancedControlsTest.Size = new System.Drawing.Size(728, 402);
+            this.advancedControlsTest.TabIndex = 0;
+            this.advancedControlsTest.Text = "Test Keyboard, Mouse and GamePad input here!";
+            this.advancedControlsTest.UpdateGameLoopWhenNotVisible = false;
+            // 
+            // multipleControls_First_Test1
+            // 
+            this.multipleControls_First_Test1.BackColor = System.Drawing.Color.LightSeaGreen;
+            this.multipleControls_First_Test1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.multipleControls_First_Test1.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.multipleControls_First_Test1.ForeColor = System.Drawing.Color.Lavender;
+            this.multipleControls_First_Test1.Location = new System.Drawing.Point(0, 0);
+            this.multipleControls_First_Test1.MouseHoverUpdatesOnly = false;
+            this.multipleControls_First_Test1.Name = "multipleControls_First_Test1";
+            this.multipleControls_First_Test1.ShouldUpdateGameLoop = true;
+            this.multipleControls_First_Test1.Size = new System.Drawing.Size(350, 402);
+            this.multipleControls_First_Test1.TabIndex = 0;
+            this.multipleControls_First_Test1.Text = "Left Map";
+            this.multipleControls_First_Test1.UpdateGameLoopWhenNotVisible = false;
+            // 
+            // multipleControls_Second_Test1
+            // 
+            this.multipleControls_Second_Test1.BackColor = System.Drawing.Color.RoyalBlue;
+            this.multipleControls_Second_Test1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.multipleControls_Second_Test1.Font = new System.Drawing.Font("Courier New", 10.2F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.multipleControls_Second_Test1.ForeColor = System.Drawing.Color.Lavender;
+            this.multipleControls_Second_Test1.Location = new System.Drawing.Point(0, 0);
+            this.multipleControls_Second_Test1.MouseHoverUpdatesOnly = false;
+            this.multipleControls_Second_Test1.Name = "multipleControls_Second_Test1";
+            this.multipleControls_Second_Test1.ShouldUpdateGameLoop = true;
+            this.multipleControls_Second_Test1.Size = new System.Drawing.Size(374, 402);
+            this.multipleControls_Second_Test1.TabIndex = 1;
+            this.multipleControls_Second_Test1.Text = "Right Map";
+            this.multipleControls_Second_Test1.UpdateGameLoopWhenNotVisible = false;
             // 
             // MainWindow
             // 
@@ -609,6 +647,8 @@
         private System.Windows.Forms.Button buttonInvalidate;
         private Tests.InvalidationTest invalidationTestControl;
         private Tests.MonoGameTest monoGameTestControl;
+        private System.Windows.Forms.CheckBox updateGameLoopCheckBox;
+        private System.Windows.Forms.CheckBox updateGameLoopNotVisibleCheckBox;
     }
 }
 

--- a/MonoGame.Forms.Tests.DX/MainWindow.cs
+++ b/MonoGame.Forms.Tests.DX/MainWindow.cs
@@ -184,5 +184,15 @@ namespace MonoGame.Forms.Tests
             Text = "MonoGame.Forms.DX";
 #endif
         }
+
+        private void updateGameLoopCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            welcomeControl.ShouldUpdateGameLoop = updateGameLoopCheckBox.Checked;
+        }
+
+        private void updateGameLoopNotVisibleCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            welcomeControl.UpdateGameLoopWhenNotVisible = updateGameLoopNotVisibleCheckBox.Checked;
+        }
     }
 }

--- a/MonoGame.Forms.Tests.DX/MainWindow.resx
+++ b/MonoGame.Forms.Tests.DX/MainWindow.resx
@@ -147,7 +147,7 @@ SOFTWARE.</value>
   <data name="toolStripDropDownButtonGitHub.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAaeSURBVHhe7VtJiBxVGO4JE1xmnKXrvapqMzgSB1ERQcTt
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAaeSURBVHhe7VtJiBxVGO4JE1xmnKXrvapqMzgSB1ERQcTt
         4IYXxY0oggdnFA96ECcHEwgSFRJwAc2gByGD6Eg04oIRD7mo6Ek9aA6iIuOKoxCJSw6uM0z0+6r+numu
         /l9PVW9VI37wQdPvX77/Vb3X71W9LnUbQRCcaq2d8o3/aGDM6/j8aTAycnhgYOC3wPr/kNFnfBe1GXOA
         tvg8SV8Js66wIfCCKwJrZ40x31aLbJVxDDvLmIwdpyggcLV8CN3tW39BK6QTjGPb3WEYWkmbPzaVy2MQ
@@ -182,7 +182,7 @@ SOFTWARE.</value>
   <data name="toolStripDropDownButtonWiki.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAaeSURBVHhe7VtJiBxVGO4JE1xmnKXrvapqMzgSB1ERQcTt
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAaeSURBVHhe7VtJiBxVGO4JE1xmnKXrvapqMzgSB1ERQcTt
         4IYXxY0oggdnFA96ECcHEwgSFRJwAc2gByGD6Eg04oIRD7mo6Ek9aA6iIuOKoxCJSw6uM0z0+6r+numu
         /l9PVW9VI37wQdPvX77/Vb3X71W9LnUbQRCcaq2d8o3/aGDM6/j8aTAycnhgYOC3wPr/kNFnfBe1GXOA
         tvg8SV8Js66wIfCCKwJrZ40x31aLbJVxDDvLmIwdpyggcLV8CN3tW39BK6QTjGPb3WEYWkmbPzaVy2MQ
@@ -217,7 +217,7 @@ SOFTWARE.</value>
   <data name="toolStripDropDownButtonTwitter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAGoAAABqCAYAAABUIcSXAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAm2SURBVHhe7ZwLcFTVGcejU2y1OtRqX9NOO22d2tppq9OH
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAm2SURBVHhe7ZwLcFTVGcejU2y1OtRqX9NOO22d2tppq9OH
         rXag+EClIgKmgDZDLdQOU2irVsSBGmtTHy0DiArjoA2vRDSBZPOQhEBeJjGQkJAQkiaEkIQkZJPde+/e
         e/fu3l17b88/c9bZZm4igX3dzfeb+QZY7uN85zvnO9/5zjk3hSAIgiAIgiAIgiAIgiAIgiAIgiAIgiAI
         giAIgiCSHI/HuK6hV1+xrVYp+K3D7Zyd69QfOSAqGWVy/aF2Lf28on+XX0rEgxFRv6WgRdu67j1314ID

--- a/MonoGame.Forms.Tests.DX/Tests/Welcome.cs
+++ b/MonoGame.Forms.Tests.DX/Tests/Welcome.cs
@@ -12,6 +12,8 @@ namespace MonoGame.Forms.Tests.Tests
         public bool EditMode = false;
         public int LastFrame = 0;
 
+        private Rectangle currentFrame;
+
         protected override void Initialize()
         {
             base.Initialize();
@@ -23,6 +25,10 @@ namespace MonoGame.Forms.Tests.Tests
         protected override void Update(GameTime gameTime)
         {
             base.Update(gameTime);
+            if (!EditMode)
+            {
+                currentFrame = Logo.DoAnimation();
+            }
         }
 
         protected override void Draw()
@@ -36,7 +42,7 @@ namespace MonoGame.Forms.Tests.Tests
                        Editor.graphics.Viewport.Height / 2,
                        Logo.PartSizeX,
                        Logo.PartSizeY),
-                       (EditMode ? Logo.GetCurrentFrame() : Logo.DoAnimation()),
+                       (EditMode ? Logo.GetCurrentFrame() : currentFrame),
                        Logo.GetDrawingColor, 
                        0f, 
                        Logo.GetOrigin, 


### PR DESCRIPTION
…date.

Hi,
Big thanks for this great library. I had a need in my own project for windows to keep updating even when they are not visible (i.e you have a different tab selected) and i thought it'd be useful for others.
I also needed to be able to control whether or not the game loop update code should be called.
To implement both of these I added two property flags to GameControl: UpdateGameLoopWhenNotVisible (defaults to false for backwards compatability) and ShouldUpdateGameLoop (defaults to true). These do what you would expect.
For testing, I modified your welcome page test with two check boxes. I had to move the animation update logic to the 'Update' method, but that is about the only change.

Thanks again!
